### PR TITLE
add a visual indicator of the object's origin when displaying a Bracket

### DIFF
--- a/source/Bracket.ts
+++ b/source/Bracket.ts
@@ -121,7 +121,9 @@ export default class Bracket extends LineSegments
         target.add(this);
 
         this.onBeforeRender = () => {
-            this.axes.scale.copy(new Vector3(1, 1, 1)).divide(target.parent.scale);
+            if(target.parent){
+                this.axes.scale.copy(new Vector3(1, 1, 1)).divide(target.parent.scale);
+            }
         }
     }
 

--- a/source/Bracket.ts
+++ b/source/Bracket.ts
@@ -15,6 +15,7 @@ import {
     Matrix4,
     Box3,
     Color,
+    AxesHelper
 } from "three";
 
 import { computeLocalBoundingBox } from "./helpers";
@@ -37,6 +38,7 @@ export interface IBracketProps
  */
 export default class Bracket extends LineSegments
 {
+    private axes :AxesHelper;
     static readonly defaultProps = {
         color: new Color("#ffd633"),
         length: 0.25
@@ -112,18 +114,27 @@ export default class Bracket extends LineSegments
 
         this.renderOrder = 1;
 
+        this.axes = new AxesHelper(1);
+        (this.axes.material as any).depthTest  = false;
+        this.axes.renderOrder = 1;
+        target.parent.add(this.axes);
+        target.add(this);
+
         this.onBeforeRender = () => {
-            target.updateMatrixWorld(false);
-            this.matrixWorld.copy(target.matrixWorld);
+            this.axes.scale.copy(new Vector3(1, 1, 1)).divide(target.parent.scale);
         }
     }
 
     dispose()
     {
+
         if (this.parent) {
             this.parent.remove(this);
         }
-
+        if(this.axes.parent){
+            this.axes.parent.remove(this.axes);
+        }
+        this.axes.dispose();
         this.geometry.dispose();
     }
 


### PR DESCRIPTION
The changes are pretty much self-explanatory : Add an axis helper on the "Bracket" showing the selected object's bound to indicate it's transform origin.

This would help communicate the difference between **Pose/Position** (move relative to transform origin) and **Settings/Transform** (move the pivot point)

In the future, this "AxesHelper" could be extended to provide "handles" to move the object in the 3D space. For the moment it's just a visual helper.

The styling is THREE's default helper, I found it more readable than an all-yellow helper but other color choices are obviously possible.